### PR TITLE
Capitalize bandit

### DIFF
--- a/src/os-popen.ipynb
+++ b/src/os-popen.ipynb
@@ -20,7 +20,7 @@
    "source": [
     "# README\n",
     "\n",
-    "This code contains naughty code that should be caught by bandit, from <https://github.com/PyCQA/bandit/blob/e0a12a973bd58f23f16b3fe84190f7bffa0e7cde/examples/os-popen.py>"
+    "This code contains naughty code that should be caught by Bandit, from <https://github.com/PyCQA/bandit/blob/e0a12a973bd58f23f16b3fe84190f7bffa0e7cde/examples/os-popen.py>"
    ]
   },
   {


### PR DESCRIPTION
Bandit should be capitalized